### PR TITLE
Add support to generate Linux ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
@@ -55,10 +52,10 @@ jobs:
           #   runner: ubuntu-latest
           #   target: riscv64gc-unknown-linux-gnu
           #   command: cross
-          # - name: Linux-arm64
-          #   runner: ubuntu-latest
-          #   target: aarch64-unknown-linux-gnu
-          #   command: cross
+          - name: Linux-arm64
+            runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            command: cross
           - name: MacOS-amd64
             runner: macos-latest
             target: x86_64-apple-darwin
@@ -76,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install requirements (Linux)
-        if: matrix.runner == 'ubuntu-latest' && matrix.command == 'cargo'
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
           sudo apt-get update
           sudo apt-get install protobuf-compiler

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm cross
+          cargo binstall --force --no-confirm cross
 
       - name: Copy config
         working-directory: tripa

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust test
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,6 +49,5 @@ jobs:
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cross
 
-      # TODO: Remove true after fix tests
       - name: Test
-        run: cargo test --workspace --no-fail-fast || true
+        run: cargo test --workspace --no-fail-fast

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,15 +1,14 @@
+# add depency for reqwest that use openssl and protobuf for celestia
 [target.riscv64gc-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:edge"
-# add depency for reqwest that use openssl and protobuf for celestia
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH protobuf-compiler",
+    "apt-get update && apt-get --assume-yes install pkg-config libssl-dev:$CROSS_DEB_ARCH protobuf-compiler",
 ]
 
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
-# add depency for reqwest that use openssl and protobuf for celestia
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH protobuf-compiler",
+    "apt-get update && apt-get --assume-yes install pkg-config libssl-dev:$CROSS_DEB_ARCH protobuf-compiler",
 ]

--- a/decode-batch/.cargo/config.toml
+++ b/decode-batch/.cargo/config.toml
@@ -1,5 +1,2 @@
-[env]
-RUST_TEST_THREADS = "1"
-
 [build]
 rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Pull Request: Linux ARM64 Support and Cache Removal in Tests

### Description

This PR introduces the following changes:

- **Linux ARM64 Support**: Added support for Linux ARM64 architecture, utilizing `cross` for builds instead of `cargo`.
- **Test Cache Removal**: Removed caching in tests to prevent quota overflow on GitHub's free tier.

Please let me know if any additional adjustments are needed.
